### PR TITLE
Updated dependencies to support io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "typed array"
   ],
   "dependencies": {
-    "bindings": "~1.1",
-    "nan": "~1.2.0",
-    "node-arraybuffer": "^1.0.11"
+    "bindings": "~1.2.1",
+    "nan": "~1.8.4",
+    "node-arraybuffer": "^1.0.12"
   },
   "devDependencies": {
     "testjs": "latest"


### PR DESCRIPTION
Updated the dependencies (nan & node-arraybuffer [https://github.com/vmolsa/node-arraybuffer/pull/1]) to support building using io.js 2. 

Please review.
